### PR TITLE
Changes as per 14/02/2023 meeting

### DIFF
--- a/docs/Controller implementation tutorial.md
+++ b/docs/Controller implementation tutorial.md
@@ -67,7 +67,6 @@ The root block, among other things holds [Managers](https://specs.amwa.tv/ms-05-
 A minimal implementation of a device will have at least three managers listed in the root block:
 
 - Device manager
-- Subscription manager
 - Class manager
 
 | ![Typical device structure](images/typical-device-structure.png) |
@@ -97,9 +96,9 @@ A controller is expected to be able to work with all the identifiers exposed by 
 
 As per the [MS-05-02](https://specs.amwa.tv/ms-05-02/branches/v1.0-dev/docs/NcObject.html#propertychanged-event) specification all control classes must inherit from `NcObject` which specifies the `PropertyChanged` event.
 
-This means any properties in any control class can be subscribed to in order to receive change notifications. Subscriptions are handled by the [Subscription manager](https://specs.amwa.tv/ms-05-02/branches/v1.0-dev/docs/Managers.html#subscription-manager).
+This means any properties in any control class can be subscribed to in order to receive change notifications.
 
-A controller is expected to [Subscribe](https://specs.amwa.tv/is-12/branches/v1.0-dev/docs/Subscribing_to_events.html) to object ids it is interested in by sending commands to the `Subscription manager`.
+A controller is expected to [Subscribe](https://specs.amwa.tv/is-12/branches/v1.0-dev/docs/Subscribing_to_events.html) to object ids it is interested in by sending `Subscription` messages as specified in [NMOS IS-12](https://specs.amwa.tv/is-12/branches/v1.0-dev/docs/Protocol_messaging.html).
 
 ### Context identity mapping (Receiver monitor example)
 

--- a/docs/Device implementation tutorial.md
+++ b/docs/Device implementation tutorial.md
@@ -55,7 +55,6 @@ As per the [MS-05-02](https://specs.amwa.tv/ms-05-02/branches/v1.0-dev/docs/Mana
 Typical managers included in the root block are:
 
 - Device manager (holds general information about the device including product information and serial numbers)
-- Subscription manager (offers means of subscribing to events thus enabling notifications)
 - Class manager (offers means of class and data type discovery)
 
 #### Worker control classes
@@ -84,10 +83,9 @@ A device is expected to offer touchpoints to map identities wherever relevant (F
 
 As per the [MS-05-02](https://specs.amwa.tv/ms-05-02/branches/v1.0-dev/docs/Blocks.html) specification all MS-05 / IS-12 devices need to expose a structure starting with the root block which always has an `oid` of 1.
 
-A minimal implementation of a device will have at least three [managers](Device%20implementation%20tutorial.md#manager-control-classes) listed in the root block:
+A minimal implementation of a device will have at least two [managers](Device%20implementation%20tutorial.md#manager-control-classes) listed in the root block:
 
 - Device manager
-- Subscription manager
 - Class manager
 
 | ![Typical device structure](images/typical-device-structure.png) |
@@ -207,9 +205,8 @@ As specified by the [IDL](https://specs.amwa.tv/ms-05-02/branches/v1.0-dev/idl/N
 
 As per the [MS-05-02](https://specs.amwa.tv/ms-05-02/branches/v1.0-dev/docs/NcObject.html#propertychanged-event) specification all control classes must inherit from `NcObject` which specifies the `PropertyChanged` event.
 
-This means any properties in any control class can be subscribed to in order to receive change notifications. Subscriptions are handled by the [Subscription manager](https://specs.amwa.tv/ms-05-02/branches/v1.0-dev/docs/Managers.html#subscription-manager).
-
-A device is expected to allow controllers to [Subscribe](https://specs.amwa.tv/is-12/branches/v1.0-dev/docs/Subscribing_to_events.html) to object ids it is interested in by correctly handling commands sent to the `Subscription manager`.
+This means any properties in any control class can be subscribed to in order to receive change notifications.
+A device is expected to allow controllers to [Subscribe](https://specs.amwa.tv/is-12/branches/v1.0-dev/docs/Subscribing_to_events.html) to object ids it is interested in by correctly handling `Subscription` messages and sending back `SubscriptionResponse` messages as specified in [NMOS IS-12](https://specs.amwa.tv/is-12/branches/v1.0-dev/docs/Protocol_messaging.html).
 
 A device is also expected to use the underlying WebSocket control protocol context and the subscriptions received in order to determine when a notification message needs to be sent to a controller.
 

--- a/docs/How To practical examples.md
+++ b/docs/How To practical examples.md
@@ -255,23 +255,6 @@ The device responds with a JSON containing `NcBlockMemberDescriptor` member desc
             "constraints": null
           },
           {
-            "role": "SubscriptionManager",
-            "oid": 5,
-            "constantOid": true,
-            "identity": {
-              "id": [
-                1,
-                3,
-                4
-              ],
-              "version": "1.0.0"
-            },
-            "userLabel": "Subscription manager",
-            "owner": 1,
-            "description": "The subscription manager offers the ability to subscribe to events on particular objects and properties",
-            "constraints": null
-          },
-          {
             "role": "ReceiverMonitor_01",
             "oid": 11,
             "constantOid": true,
@@ -622,43 +605,28 @@ NC-01 returns the new value of the `right-gain` value in the response.
 
 **Subscribe to property changes for the `right-gain`**
 
-Add a subscription notification to changes on the `right-gain` control by sending a subscription command to the SubscriptionManager. Paste in the JSON formatted command below to subscribe for changes. Note that the command is directed to the Subscription Manager's (oid 5) method (3m1) which is described in the tutorial section of this document and targets the `right-gain` by using its `oid` of 23 as the emitter `oid`.
+Add a subscription to changes on the `right-gain` control by sending a `Subscription` message. Paste in the JSON formatted command below to subscribe for changes. Note that the message targets the `right-gain` by using its `oid` of 23 as the emitter `oid`.
 
 ```json
 {
   "protocolVersion": "1.0.0",
-  "messageType": 0,
-  "commands": [
-    {
-      "handle": 5,
-      "oid": 5,
-      "methodId": {
-        "level": 3,
-        "index": 1
-      },
-      "arguments": {
-        "oid": 23
-      }
-    }
+  "messageType": 3,
+  "subscriptions": [
+    23
   ]
 }
 ```
 
 **Expected Results**
 
-The Subscription Manager will respond with a message indicating the subscription request was accepted.
+The device will respond with a `SubscriptionResponse` message indicating the subscription request was accepted.
 
 ```json
 {
   "protocolVersion": "1.0.0",
-  "messageType": 1,
-  "responses": [
-    {
-      "handle": 5,
-      "result": {
-        "status": 200
-      }
-    }
+  "messageType": 4,
+  "subscriptions": [
+    23
   ]
 }
 ```
@@ -1037,7 +1005,7 @@ The changes to the original Server.ts file are simply replacements of the NMOS C
 ```typescript
 @@ -14,7 +14,7 @@ import { SessionManager } from './SessionManager';
  import { NcBlock, RootBlock } from './NCModel/Blocks';
- import { NcClassManager, NcDeviceManager, NcSubscriptionManager } from './NCModel/Managers';
+ import { NcClassManager, NcDeviceManager } from './NCModel/Managers';
  import { NcIoDirection, NcLockState, NcPort, NcPortReference, NcSignalPath, NcTouchpointNmos, NcTouchpointResourceNmos } from './NCModel/Core';
 -import { NcDemo, NcGain, NcReceiverMonitor } from './NCModel/Features';
 +import { NcDemo, NcGainCustom, NcReceiverMonitor } from './NCModel/Features';


### PR DESCRIPTION
- Remove references to Subscription Manager
- Correct subscription sections in line with the new IS-12 messages (Subscription and SubscriptionResponse) messages.
- Correct subscription example